### PR TITLE
Update Agent Mag org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,10 +1,10 @@
-<div align="center">
+# Agent Mag
 
-<a href="https://theagentmag.com"><img src="https://raw.githubusercontent.com/Agent-mag/.github/main/profile/agentmag-banner-github.png" alt="Agent Mag" width="100%" /></a>
+![Agent Mag](https://raw.githubusercontent.com/Agent-mag/.github/main/profile/agentmag-banner-github.png)
 
-**Free, open-source tools and agent skills for the AI builder community.**
+**Free, open-source tools, skills, and local model install commands for the AI builder community.**
 
-We believe the best way to serve builders is to build for them — in the open, with no strings attached.
+We believe the best way to serve builders is to build for them in the open, with no strings attached.
 
 [![Website](https://img.shields.io/badge/theagentmag.com-000?style=for-the-badge&logo=google-chrome&logoColor=white)](https://theagentmag.com)
 [![npm](https://img.shields.io/npm/v/agentmag?style=for-the-badge&color=000&label=npm)](https://www.npmjs.com/package/agentmag)
@@ -12,111 +12,94 @@ We believe the best way to serve builders is to build for them — in the open, 
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/company/theagentmag)
 [![Newsletter](https://img.shields.io/badge/Newsletter-Subscribe_Free-000?style=for-the-badge&logo=substack&logoColor=white)](https://theagentmag.com/#newsletter)
 
-</div>
+---
+
+## Quick Start
+
+```bash
+# Install an agent skill config bundle
+npx agentmag add skill web-browsing
+
+# Install a GitHub Actions workflow tool
+npx agentmag add tool seo-geo-reviewer
+
+# Pull a local Ollama model
+npx agentmag add model qwen3.6
+
+# Search the registry
+npx agentmag search "database"
+```
+
+`agentmag add model <name>` wraps `ollama pull <name>`, so local models stay in your normal Ollama library.
 
 ---
 
 ## Our Repos
 
 | Repo | What It Is | Install / Contribute |
-|------|-----------|---------------------|
-| [`skills`](https://github.com/Agent-mag/skills) | Open registry of installable agent skills — config bundles (prompts, tools, manifests) | `npx agentmag add skill <name>` |
-| [`tools`](https://github.com/Agent-mag/tools) | Free, open-source tools for agent builders — GitHub Actions, CLIs, utilities | `npx agentmag add tool <name>` |
+|------|------------|----------------------|
+| [`agentmag`](https://github.com/Agent-mag/agentmag) | Agent Mag website, model directory, skill registry, and npm CLI | `npx agentmag add skill\|tool\|model <name>` |
+| [`skills`](https://github.com/Agent-mag/skills) | Open registry of installable agent skills: prompts, tools, manifests | `npx agentmag add skill <name>` |
+| [`tools`](https://github.com/Agent-mag/tools) | Free tools for agent builders: GitHub Actions, CLIs, utilities | `npx agentmag add tool <name>` |
 | [`roadmap`](https://github.com/Agent-mag/roadmap) | Public roadmap, feature proposals, and RFCs | Propose via issue |
-| [`.github`](https://github.com/Agent-mag/.github) | Org profile, community health files, templates | — |
+| [`.github`](https://github.com/Agent-mag/.github) | Org profile, community health files, templates | PRs welcome |
 
-All repos are **MIT-licensed**. The Agent Mag platform ([theagentmag.com](https://theagentmag.com)) is proprietary — these public repos are the open-source ecosystem around it.
-
----
-
-## Quick Start
-
-```bash
-# Install an agent skill (config bundle — prompts, tools, manifests)
-npx agentmag add skill web-browsing
-
-# Install a tool (GitHub Action workflow)
-npx agentmag add tool seo-geo-reviewer
-
-# Search the registry
-npx agentmag search "database"
-```
+All open ecosystem repos are MIT-licensed. The Agent Mag platform at [theagentmag.com](https://theagentmag.com) is the product surface around the open registry.
 
 ---
 
 ## The Platform
 
-<table>
-<tr>
-<td width="50%" valign="top">
-
 ### Deep-Dive Articles
-Long-form technical content on agent architectures, production patterns, model benchmarks, and case studies. Written by engineers, not content marketers.
 
-**[Read articles →](https://theagentmag.com)**
+Long-form technical content on agent architectures, production patterns, model benchmarks, and case studies.
 
-</td>
-<td width="50%" valign="top">
+**[Read articles](https://theagentmag.com)**
 
-### 136+ Free Tools Directory
-The most comprehensive directory of AI agent development tools — frameworks, SDKs, testing utilities, observability platforms, and more.
+### AI Models Directory
 
-**[Browse tools →](https://theagentmag.com/tools)**
+Search OpenRouter API models and local Ollama models by context, modality, pricing, tags, and install commands.
 
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
+**[Browse models](https://theagentmag.com/models)**
 
 ### Open Skills Registry
-Installable agent skills — config bundles you can drop into any framework with one command. Prompts, tool definitions, manifests — not executable code.
 
-**[Explore skills →](https://theagentmag.com/skills)**
+Installable agent skills you can drop into coding agents as config bundles: prompts, tool definitions, manifests, and templates.
 
-</td>
-<td width="50%" valign="top">
+**[Explore skills](https://theagentmag.com/skills)**
+
+### Free Tools Directory
+
+Frameworks, SDKs, testing utilities, observability platforms, and workflow tools for AI agent builders.
+
+**[Browse tools](https://theagentmag.com/tools)**
 
 ### Curated Job Board
-AI agent engineering roles from companies actually building agents in production. Agent-specific roles at companies that get it.
 
-**[View jobs →](https://theagentmag.com/jobs)**
+AI agent engineering roles from companies building agents in production.
 
-</td>
-</tr>
-<tr>
-<td width="50%" valign="top">
+**[View jobs](https://theagentmag.com/jobs)**
 
-### Events Calendar
-Conferences, hackathons, meetups, and workshops focused on AI agents. Never miss a gathering of the builder community.
+### Events And Resources
 
-**[See events →](https://theagentmag.com/events)**
+Conferences, hackathons, tutorials, research papers, and learning paths for going deeper on agent systems.
 
-</td>
-<td width="50%" valign="top">
-
-### Resources & Courses
-Curated learning paths, tutorials, research papers, and courses for going deeper on specific agent topics.
-
-**[Find resources →](https://theagentmag.com/resources)**
-
-</td>
-</tr>
-</table>
+**[See events](https://theagentmag.com/events)** | **[Find resources](https://theagentmag.com/resources)**
 
 ---
 
 ## What We're Building Next
 
 | Area | What to Expect | Status |
-|------|---------------|--------|
+|------|----------------|--------|
 | **Agent Testing** | Evaluation harnesses, conversation replay, assertion libraries | In progress |
 | **Prompt Engineering** | Prompt linters, version control, A/B testing utilities | In progress |
+| **Local Models** | Better Ollama discovery, install stats, and agent runtime examples | In progress |
 | **Observability** | Trace viewers, cost trackers, latency profilers | Planned |
-| **MCP & Tool Use** | Model Context Protocol servers, tool schema validators | Planned |
-| **Multi-Agent** | Orchestration templates, message bus adapters | Planned |
+| **MCP & Tool Use** | MCP servers, tool schema validators, and registry metadata | Planned |
 | **Deployment** | Dockerfiles, CI/CD templates, infra-as-code | Planned |
 
-Have a tool you want us to build? [Open a discussion →](https://github.com/orgs/Agent-mag/discussions)
+Have a tool, skill, or model workflow you want us to support? [Open a discussion](https://github.com/orgs/Agent-mag/discussions).
 
 ---
 
@@ -126,6 +109,7 @@ Have a tool you want us to build? [Open a discussion →](https://github.com/org
 |---------------------|-------|
 | Submit a new agent skill | PR to [`Agent-mag/skills`](https://github.com/Agent-mag/skills) |
 | Submit a new tool | PR to [`Agent-mag/tools`](https://github.com/Agent-mag/tools) |
+| Improve the CLI or model directory | PR to [`Agent-mag/agentmag`](https://github.com/Agent-mag/agentmag) |
 | Propose a feature | Issue on [`Agent-mag/roadmap`](https://github.com/Agent-mag/roadmap) |
 | Report a bug | Issue in the relevant repo |
 | Write an article | Pitch at [editorial@theagentmag.com](mailto:editorial@theagentmag.com) |
@@ -145,10 +129,6 @@ Have a tool you want us to build? [Open a discussion →](https://github.com/org
 
 ---
 
-<div align="center">
-
-**Est. 2026** · San Francisco · [theagentmag.com](https://theagentmag.com)
+**Est. 2026** | San Francisco | [theagentmag.com](https://theagentmag.com)
 
 Built for builders, by builders.
-
-</div>


### PR DESCRIPTION
## Summary
- Refresh the Agent Mag organization profile README with plain Markdown.
- Add the main `agentmag` repo to the org repo table.
- Document `npx agentmag add model <name>` alongside skill and tool installs.
- Add the AI models directory to the platform overview.

## Why
The GitHub org homepage should reflect the current Agent Mag platform: website, skills, tools, models, and npm CLI.

## Verification
- Markdown-only README check: no raw centered HTML blocks or table markup remain.
